### PR TITLE
Fix getStartIndex end of preproc directives finding

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function getStartIndex (tokens) {
   for (var i = 0; i < tokens.length; i++) {
     var token = tokens[i]
     if (token.type === 'preprocessor') {
-      if (/^#(extension|version)/.test(token.data)) {
+      if (/^#(extension|version|endif)/.test(token.data)) {
         start = Math.max(start, i)
       }
     } else if (token.type === 'keyword' && token.data === 'precision') {


### PR DESCRIPTION
[Ran into this in our browser engine](https://github.com/webmixedreality/exokit/issues/493):

```
#version 100
#extension GL_EXT_shader_texture_lod : require
#ifdef GL_FRAGMENT_PRECISION_HIGH
  precision highp float;
#else
 precision mediump float;
#endif
uniform samplerCube uT0;
varying vec3 vC;
void main(void) {
  gl_FragColor = textureCubeLodEXT(uT0, vC, 1.0);
}
```

would compile to

```
#version 150
#extension GL_ARB_separate_shader_objects : enable

#ifdef GL_FRAGMENT_PRECISION_HIGH
  precision highp float;
#else
 precision mediump float;
out vec4 unique_fragColor;
#endif
uniform samplerCube uT0;
in vec3 vC;
void main(void) {
  unique_fragColor = textureLod(uT0, vC, 1.0);
}
```

Note the misplaced `out vec4 unique_fragColor;`